### PR TITLE
Find gurobi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.0 )
 
-project( MACHINA VERSION 1.0 )
+project( MACHINA VERSION 1.1 )
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR} ${CMAKE_MODULE_PATH} )
 

--- a/FindGUROBI.cmake
+++ b/FindGUROBI.cmake
@@ -1,20 +1,61 @@
-# copied from https://searchcode.com/codesearch/raw/30585458/
+# Simply provide the home of gurobi within the double apices here below
+# REQUIREMENT 1: Full path to Gurobi's home which must have a name similar to "gurobiXXX" where XXX is the version.
+# REQUIREMENT 2: Gurobi's must contain either (1) `lib` and `include` directories, (2) a folder named either `linux64` or `mac64` which correspondingly contains `lib` and `include` directories
+
+set(GUROBI_HOME "" CACHE STRING "Path where Gurobi is installed")
+
+
+
+if(EXISTS ${GUROBI_HOME} )
+    message( "-- Gurobi's home is set to: " ${GUROBI_HOME} )
+
+    string( REGEX MATCH "gurobi[0-9][0-9][0-9]" GUROBI_VER_FULL ${GUROBI_HOME} )
+    string( REGEX MATCH "[0-9][0-9][0-9]" GUROBI_VER ${GUROBI_VER_FULL} )
+
+    ## If the previous process fails to find the correct version of Gurobi in variable GUROBI_VER (e.g. 702, 751, 801) please provide the correct version here below by properly setting the version instead of XXX and uncommented the command
+    ## set(GUROBI_VER "XXX")
+
+    string(STRIP ${GUROBI_VER} GUROBI_VER )
+    message( "-- The retrieved version of Gurobi is: " ${GUROBI_VER} )
+
+    string(SUBSTRING ${GUROBI_VER} 0 2 GUROBI_VER_LIB)
+
+    message( "-- The retrieved name of version-specific library is " gurobi ${GUROBI_VER_LIB} )
+
+    file( GLOB GUROBI_LIB_FILE ${GUROBI_HOME}/linux64/lib/libgurobi${GUROBI_VER_LIB}.* )
+    if( GUROBI_LIB_FILE )
+    	message( "-- Gurobi library " ${GUROBI_LIB_FILE} " found in " ${GUROBI_HOME} "/linux64/lib/" )
+    else()
+	file( GLOB GUROBI_LIB_FILE ${GUROBI_HOME}/mac64/lib/libgurobi${GUROBI_VER_LIB}.* )
+	if( GUROBI_LIB_FILE )
+    	    message( "-- Gurobi library " ${GUROBI_LIB_FILE} " found in " ${GUROBI_HOME} "/mac64/lib/" )
+    	else()
+	    file( GLOB GUROBI_LIB_FILE ${GUROBI_HOME}/lib/libgurobi${GUROBI_VER_LIB}.* )
+	    if( GUROBI_LIB_FILE )
+    	    	message( "-- Gurobi library " ${GUROBI_LIB_FILE} " found in " ${GUROBI_HOME} "/lib/" )
+	    else()
+	        message( FATAL_ERROR "libgurobi" ${GUROBI_VER_LIB} ".* not found either in " ${GUROBI_HOME} "/linux64/lib/ or " ${GUROBI_HOME} "/mac64/lib/ or " ${GUROBI_HOME} "/lib, please check the file exists and provide the correct PATH or manually set Gurobi's version. CMake will exit." )
+	    endif()
+	endif()
+    endif()
+
+endif()
+
 FIND_PATH(GUROBI_INCLUDE_DIR
           NAMES "gurobi_c++.h" "gurobi_c.h"
-          PATHS /Library/gurobi651/mac64/include/ /usr/local/gurobi651/linux64/include/
+          PATHS /Library/gurobi651/mac64/include/ /usr/local/gurobi651/linux64/include/ ${GUROBI_HOME}/linux64/include/ ${GUROBI_HOME}/mac64/include/ ${GUROBI_HOME}/include/
           DOC "Gurobi include directory")
 
 FIND_LIBRARY(GUROBI_CPP_LIB
              NAMES gurobi_c++ 
-             PATHS /Library/gurobi651/mac64/lib/ /usr/local/gurobi651/linux64/lib/
+             PATHS /Library/gurobi651/mac64/lib/ /usr/local/gurobi651/linux64/lib/ ${GUROBI_HOME}/linux64/lib/ ${GUROBI_HOME}/mac64/lib/ ${GUROBI_HOME}/lib/
              DOC "Gurobi C++ Libraries")
 
 FIND_LIBRARY(GUROBI_LIB
-             NAMES gurobi65
-             PATHS /Library/gurobi651/mac64/lib/ /usr/local/gurobi651/linux64/lib/
+             NAMES "gurobi${GUROBI_VER_LIB}"
+             PATHS /Library/gurobi651/mac64/lib/ /usr/local/gurobi651/linux64/lib/ ${GUROBI_HOME}/linux64/lib/ ${GUROBI_HOME}/mac64/lib/ ${GUROBI_HOME}/lib/
              DOC "Gurobi C Libraries")
 
 set(GUROBI_LIBRARIES ${GUROBI_CPP_LIB} ${GUROBI_LIB})
 
 set(GUROBI_FOUND TRUE)
-

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To compile MACHINA, execute the following commands from the root of the reposito
 In case CMake fails to detect LEMON or Gurobi, run the following command with adjusted paths:
 
     $ cmake -DLIBLEMON_ROOT=~/lemon \
-    -DGUROBI_INCLUDE_DIR=/usr/local/gurobi702/linux64/include \
-    -DGUROBI_CPP_LIB=/usr/local/gurobi702/linux64/lib/libgurobi_c++.a \
-    -DGUROBI_LIB=/usr/local/lib/libgurobi70.so ..
+    -DGUROBI_HOME=/path/to/gurobiXXX
+
+where `XXX` is the 3-digit version of gurobi.
 
 The compilation results in the following files in the `build` directory:
 


### PR DESCRIPTION
I'm using the `FindGUROBI.cmake` from HATCHet, without modifying the hardcoded gurobi path that the cmake file was using earlier (only adding additional paths to the end).

Also modified the README a bit to reflect this.